### PR TITLE
Patch paths for Windows

### DIFF
--- a/output/candidates_2023-07-28T19-03-53.json
+++ b/output/candidates_2023-07-28T19-03-53.json
@@ -1,0 +1,62 @@
+{
+    "ARE": {
+        "cash_flow_increase_rate": 0.2392130520381969,
+        "dcf_valuation_per_share": 273.77549106532035,
+        "dcf_discount_per_share": 158.40549106532035,
+        "dcf_discount_ratio": 2.373021505290113
+    },
+    "AMT": {
+        "cash_flow_increase_rate": 0.8584430064511671,
+        "dcf_valuation_per_share": 276.3937207309969,
+        "dcf_discount_per_share": 85.2437207309969,
+        "dcf_discount_ratio": 1.4459519787130364
+    },
+    "APTV": {
+        "cash_flow_increase_rate": 0.8728816327324626,
+        "dcf_valuation_per_share": 142.8413330629496,
+        "dcf_discount_per_share": 49.15133306294959,
+        "dcf_discount_ratio": 1.5246166406548147
+    },
+    "BA": {
+        "cash_flow_increase_rate": 0.8892565901632735,
+        "dcf_valuation_per_share": 476.98475188246107,
+        "dcf_discount_per_share": 263.6647518824611,
+        "dcf_discount_ratio": 2.236005774809962
+    },
+    "BXP": {
+        "cash_flow_increase_rate": 0.9707740709964713,
+        "dcf_valuation_per_share": 606.9869102298828,
+        "dcf_discount_per_share": 556.3469102298828,
+        "dcf_discount_ratio": 11.986313393165142
+    },
+    "DUK": {
+        "cash_flow_increase_rate": 0.7311876206000459,
+        "dcf_valuation_per_share": 92.21931398881843,
+        "dcf_discount_per_share": 2.539313988818421,
+        "dcf_discount_ratio": 1.0283152764141215
+    },
+    "F": {
+        "cash_flow_increase_rate": 0.467749545430743,
+        "dcf_valuation_per_share": 19.495842828307254,
+        "dcf_discount_per_share": 7.105842828307253,
+        "dcf_discount_ratio": 1.5735143525671713
+    },
+    "O": {
+        "cash_flow_increase_rate": 0.34830607712486783,
+        "dcf_valuation_per_share": 126.93776993596315,
+        "dcf_discount_per_share": 67.23776993596314,
+        "dcf_discount_ratio": 2.1262608029474563
+    },
+    "TDY": {
+        "cash_flow_increase_rate": 0.9138387233299898,
+        "dcf_valuation_per_share": 852.1252835597353,
+        "dcf_discount_per_share": 454.7052835597353,
+        "dcf_discount_ratio": 2.1441429308030178
+    },
+    "WELL": {
+        "cash_flow_increase_rate": 0.6480697643407946,
+        "dcf_valuation_per_share": 172.1960485331442,
+        "dcf_discount_per_share": 96.43604853314419,
+        "dcf_discount_ratio": 2.2729151073540677
+    }
+}

--- a/stonks/storage.py
+++ b/stonks/storage.py
@@ -14,7 +14,7 @@ class DataStorage:
     @staticmethod
     def formatted_time_now() -> str:
         """Compute a nicely formatted timestamp string."""
-        return str(datetime.now().isoformat())[:-7]
+        return str(datetime.now().isoformat()).replace(":", "-")[:-7]
 
     @staticmethod
     def timestamped_file(name: str, suffix: str) -> Path:


### PR DESCRIPTION
# Patch paths for Windows

## Fixes

- Replaced `:`  with `-` in file names time formatting fixing an unhandled crash when running on Windows...
